### PR TITLE
Fix include class name collisions in cache adapters

### DIFF
--- a/src/Adapter/ProtectedCachedAdapter.php
+++ b/src/Adapter/ProtectedCachedAdapter.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\S3\Adapter;
 
 use League\Flysystem\Cached\CachedAdapter;
-use SilverStripe\Assets\Flysystem\ProtectedAdapter;
+use SilverStripe\Assets\Flysystem\ProtectedAdapter as SilverStripeProtectedAdapter;
 
-class ProtectedCachedAdapter extends CachedAdapter implements ProtectedAdapter
+class ProtectedCachedAdapter extends CachedAdapter implements SilverStripeProtectedAdapter
 {
     public function getProtectedUrl($path)
     {

--- a/src/Adapter/PublicCachedAdapter.php
+++ b/src/Adapter/PublicCachedAdapter.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\S3\Adapter;
 
 use League\Flysystem\Cached\CachedAdapter;
-use SilverStripe\Assets\Flysystem\PublicAdapter;
+use SilverStripe\Assets\Flysystem\PublicAdapter as SilverStripePublicAdapter;
 
-class PublicCachedAdapter extends CachedAdapter implements PublicAdapter
+class PublicCachedAdapter extends CachedAdapter implements SilverStripePublicAdapter
 {
     public function getPublicUrl($path)
     {


### PR DESCRIPTION
This PR is fixing the import name collisions that appears when the module is used with SilverStripe 4.4.4.

The issue is:
when running 
`$ vendor/bin/sake dev/build flush=all`

this error is appearing:
```
PHP Fatal error:  Cannot use SilverStripe\Assets\Flysystem\ProtectedAdapter as ProtectedAdapter because the name is already in use in /home/dev/Code/vendor/silverstripe/s3/src/Adapter/ProtectedCachedAdapter.php on line 6
PHP Stack trace:
PHP   1. {main}() /home/dev/Code/vendor/silverstripe/framework/cli-script.php:0
PHP   2. SilverStripe\Control\HTTPApplication->handle() /home/dev/Code/vendor/silverstripe/framework/cli-script.php:22
PHP   3. SilverStripe\Control\HTTPApplication->execute() /home/dev/Code/vendor/silverstripe/framework/src/Control/HTTPApplication.php:118
PHP   4. SilverStripe\Control\HTTPApplication->callMiddleware() /home/dev/Code/vendor/silverstripe/framework/src/Control/HTTPApplication.php:137
PHP   5. SilverStripe\Control\HTTPApplication->SilverStripe\Control\{closure}() /home/dev/Code/vendor/silverstripe/framework/src/Control/Middleware/HTTPMiddlewareAware.php:65
PHP   6. SilverStripe\Core\CoreKernel->boot() /home/dev/Code/vendor/silverstripe/framework/src/Control/HTTPApplication.php:135
PHP   7. SilverStripe\Core\CoreKernel->bootManifests() /home/dev/Code/vendor/silverstripe/framework/src/Core/CoreKernel.php:194
PHP   8. SilverStripe\Core\Manifest\ModuleManifest->sort() /home/dev/Code/vendor/silverstripe/framework/src/Core/CoreKernel.php:527
PHP   9. SilverStripe\Core\Config\Config_ForClass->uninherited() /home/dev/Code/vendor/silverstripe/framework/src/Core/Manifest/ModuleManifest.php:234
PHP  10. SilverStripe\Core\Config\Config_ForClass->get() /home/dev/Code/vendor/silverstripe/framework/src/Core/Config/Config_ForClass.php:129
PHP  11. SilverStripe\Config\Collections\CachedConfigCollection->get() /home/dev/Code/vendor/silverstripe/framework/src/Core/Config/Config_ForClass.php:96
PHP  12. SilverStripe\Config\Collections\CachedConfigCollection->getCollection() /home/dev/Code/vendor/silverstripe/config/src/Collections/CachedConfigCollection.php:88
PHP  13. call_user_func:{/home/dev/Code/vendor/silverstripe/config/src/Collections/CachedConfigCollection.php:139}() /home/dev/Code/vendor/silverstripe/config/src/Collections/CachedConfigCollection.php:139
PHP  14. SilverStripe\Core\Config\CoreConfigFactory->SilverStripe\Core\Config\{closure}() /home/dev/Code/vendor/silverstripe/config/src/Collections/CachedConfigCollection.php:139
PHP  15. SilverStripe\Core\Config\CoreConfigFactory->createCore() /home/dev/Code/vendor/silverstripe/framework/src/Core/Config/CoreConfigFactory.php:67
PHP  16. SilverStripe\Config\Collections\MemoryConfigCollection->transform() /home/dev/Code/vendor/silverstripe/framework/src/Core/Config/CoreConfigFactory.php:92
PHP  17. SilverStripe\Config\Transformer\PrivateStaticTransformer->transform() /home/dev/Code/vendor/silverstripe/config/src/Collections/MemoryConfigCollection.php:73
PHP  18. class_exists() /home/dev/Code/vendor/silverstripe/config/src/Transformer/PrivateStaticTransformer.php:43
PHP  19. spl_autoload_call() /home/dev/Code/vendor/silverstripe/config/src/Transformer/PrivateStaticTransformer.php:43
PHP  20. Composer\Autoload\ClassLoader->loadClass() /home/dev/Code/vendor/silverstripe/config/src/Transformer/PrivateStaticTransformer.php:43
PHP  21. Composer\Autoload\includeFile() /home/dev/Code/vendor/composer/ClassLoader.php:322
```

the 2 files affected are:
`src/Adapter/ProtectedCachedAdapter.php` and `src/Adapter/PublicCachedAdapter.php`

currently in `src/Adapter/`
`PublicAdapter.php` and `ProtectedAdapter.php`
are already using the class aliased:
```use SilverStripe\Assets\Flysystem\ProtectedAdapter as SilverstripeProtectedAdapter;```

After applying the changes in this PR, the error is not appearing and `sake dev/build` can proceed.