### PR TITLE
Allow empty prefix for {Public,Protected}Adapter

### DIFF
--- a/src/Adapter/ProtectedAdapter.php
+++ b/src/Adapter/ProtectedAdapter.php
@@ -19,12 +19,13 @@ class ProtectedAdapter extends AwsS3Adapter implements SilverstripeProtectedAdap
      */
     protected $expiry = 300;
 
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = null, array $options = [])
     {
         if (!$bucket) {
             throw new InvalidArgumentException("AWS_BUCKET_NAME environment variable not set");
         }
-        if (!$prefix) {
+        if ($prefix === null) {
+            // prefix can be an empty but needs to be set (not null)
             $prefix = 'protected';
         }
         parent::__construct($client, $bucket, $prefix, $options);

--- a/src/Adapter/PublicAdapter.php
+++ b/src/Adapter/PublicAdapter.php
@@ -9,12 +9,13 @@ use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
 
 class PublicAdapter extends AwsS3Adapter implements SilverstripePublicAdapter
 {
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = null, array $options = [])
     {
         if (!$bucket) {
             throw new InvalidArgumentException("AWS_BUCKET_NAME environment variable not set");
         }
-        if (!$prefix) {
+        if ($prefix === null) {
+            // prefix can be an empty but needs to be set (not null)
             $prefix = 'public';
         }
         parent::__construct($client, $bucket, $prefix, $options);


### PR DESCRIPTION
The prefix is not always used in the adapters.

This PR allows to make it optional.

an example where no prefix is used is (last line):

```
---
Name: custom-silverstripe-s3
After:
  - '#silverstripes3-flysystem'
---
SilverStripe\Core\Injector\Injector:
  Aws\S3\S3Client:
    constructor:
      configuration:
        region: eu-central-1
        version: latest
        credentials:
          key: '`AWS_ACCESS_KEY_ID`'
          secret: '`AWS_SECRET_ACCESS_KEY`'
  SilverStripe\S3\Adapter\PublicAdapter:
    constructor:
      s3Client: '%$Aws\S3\S3Client'
      bucket: '`AWS_BUCKET_NAME`'
      prefix: '' # <---- HERE no prefix is being used
```