### PR TITLE
FIX: Fixed example YML config structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,23 @@ If running outside of an EC2 instance it will be necessary to specify an API key
 
 **Example YML Config when running outside of EC2:**
 
-		---
-		Only:
-		envvarset: AWS_BUCKET_NAME
-		After:
-		- '#assetsflysystem'
-		---
-		SilverStripe\Core\Injector\Injector:
-		Aws\S3\S3Client:
-			constructor:
-			configuration:
-				region: '`AWS_REGION`'
-				version: latest
-				credentials:
-				key: '`AWS_ACCESS_KEY_ID`'
-				secret: '`AWS_SECRET_ACCESS_KEY`'
+```yml
+---
+Only:
+  envvarset: AWS_BUCKET_NAME
+After:
+  - '#assetsflysystem'
+---
+SilverStripe\Core\Injector\Injector:
+  Aws\S3\S3Client:
+    constructor:
+      configuration:
+        region: '`AWS_REGION`'
+        version: latest
+        credentials:
+          key: '`AWS_ACCESS_KEY_ID`'
+          secret: '`AWS_SECRET_ACCESS_KEY`'
+```
 
 ## Installation
 


### PR DESCRIPTION
This PR updates the example configuration shown in the README. The indentation is incorrect and causes an error on build