### PR TITLE
FEATURE: added ability to set a CDN domain for public assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ If running outside of an EC2 instance it will be necessary to specify an API key
 				key: '`AWS_ACCESS_KEY_ID`'
 				secret: '`AWS_SECRET_ACCESS_KEY`'
 
+## (Optional) CDN Implementation
+
+If you're serving assets from S3, it's recommended that you utilise CloudFront. This improves performance and security over exposing from S3 directly.
+
+Once you've set up your CloudFront distribution, ensure that assets are reachable within the `assets` directory of the cdn (for example; https://cdn.example.com/assets/Uploads/file.jpg) and set the following environment variable:
+
+* `AWS_PUBLIC_CDN_PREFIX`: Your CloudFront distribution domain that has access to the bucket you want to access
+
+For example, adding this to your `.env`:
+
+`AWS_PUBLIC_CDN_PREFIX='https://cdn.example.com/'`
+
+will change your URLs from something like:
+
+`https://s3.ap-southeast-2.amazonaws.com/mycdn/public/example/live/assets/Uploads/file.jpg`
+
+to something like:
+
+`https://cdn.example.com/assets/Uploads/file.jpg`
+
+ 
 ## Installation
 
 * Define the environment variables listed above.
@@ -90,6 +111,8 @@ Make sure you replace `<bucket-name>` below with the appropriate values.
 	}
 }
 ```
+
+If you are utilising a CloudFront distribution for your public assets, you will have the option of securing your S3 bucket against all public access while still allowing access to your `public` files via your CloudFront distribution and access to your `protected` files via signed URLs.
 
 ## Uninstalling
 

--- a/_config/assets.yml
+++ b/_config/assets.yml
@@ -51,7 +51,7 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\ProtectedAdapter'
       cache: '%$League\Flysystem\Cached\Storage\Adapter.protected'
-#---
+---
 Name: silverstripes3-assetscore
 Only:
   envvarset: AWS_BUCKET_NAME
@@ -62,3 +62,19 @@ SilverStripe\Core\Injector\Injector:
   # Define our SS asset backend
   SilverStripe\Assets\Storage\AssetStore:
     class: SilverStripe\Assets\Flysystem\FlysystemAssetStore
+---
+Name: silverstripes3-cdn
+Only:
+  envvarset: AWS_PUBLIC_CDN_PREFIX
+After:
+  - '#assetsflysystem'
+  - '#silverstripes3-flysystem'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\S3\Adapter\PublicAdapter:
+    class: SilverStripe\S3\Adapter\PublicCDNAdapter
+    constructor:
+      s3Client: '%$Aws\S3\S3Client'
+      bucket: '`AWS_BUCKET_NAME`'
+      prefix: '`AWS_PUBLIC_BUCKET_PREFIX`'
+      cdnPrefix: '`AWS_PUBLIC_CDN_PREFIX`'

--- a/src/Adapter/PublicCDNAdapter.php
+++ b/src/Adapter/PublicCDNAdapter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\S3\Adapter;
+
+use Aws\S3\S3Client;
+use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
+use SilverStripe\Control\Controller;
+use const ASSETS_DIR;
+
+/**
+ * Class PublicCDNAdapter
+ * @package SilverStripe\S3\Adapter
+ */
+class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapter
+{
+    protected $CDNPrefix;
+
+    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix, array $options = [])
+    {
+        $this->CDNPrefix = $cdnPrefix;
+        parent::__construct($client, $bucket, $prefix, $options);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return string
+     */
+    public function getPublicUrl($path)
+    {
+        return Controller::join_links($this->CDNPrefix, ASSETS_DIR, $path);
+    }
+}


### PR DESCRIPTION
This PR adds the optional configuration of a CDN to prefix public assets, and I've updated the README to demonstrate how the CDN is to be setup. 

I'm using this code in multiple production sites with no issue, it's a very simple implementation.

I'm using a CDN to serve both assets and resources (I've got a task to sync my resources folder in my CI after composer install), hence why I've added the suffix of `assets`, but this may not reflect everyone's setup. 

Any feedback is welcome!