### PR TITLE
BUG Disable Asset-admin cache busting to avoid invalidating request signature

### DIFF
--- a/_config/assetadmin.yml
+++ b/_config/assetadmin.yml
@@ -8,3 +8,8 @@ SilverStripe\AssetAdmin\Model\ThumbnailGenerator:
   thumbnail_links:
     protected: url
     public: url
+
+# Asset-admin adds a `vid` parameter to preview URLs by default.
+# This confuses the AWS signature for protected assets, so we disable it.
+SilverStripe\AssetAdmin\Controller\AssetAdmin:
+  bust_cache: false


### PR DESCRIPTION
When linking to a private file, the S3 adapter adds a "signature" parameter to the file which AWS validates before letting you see the file. However, Asset-admin adds a `vid` parameter to some preview URLs to bust browser caches which invalidates the signature.

We've added a new config flag to asset admin that disables this cache busting logic. https://github.com/silverstripe/silverstripe-asset-admin/pull/1119

This PR updates the s3 module to automaticly disable cache busting.

# Parent issue
* fixes https://github.com/silverstripe/silverstripe-asset-admin/issues/1026