### PR TITLE
Use in-memory cache instead of using a long-lived filesystem cache

### DIFF
--- a/_config/assets.yml
+++ b/_config/assets.yml
@@ -23,34 +23,24 @@ SilverStripe\Core\Injector\Injector:
       prefix: '`AWS_PUBLIC_BUCKET_PREFIX`'
   League\Flysystem\Cached\Storage\Memory.public:
     class: League\Flysystem\Cached\Storage\Memory
-  League\Flysystem\Cached\Storage\Adapter.public:
-    class: League\Flysystem\Cached\Storage\Adapter
-    constructor:
-      adapter: '%$League\Flysystem\Adapter\Local'
-      file: 's3metadata/public'
-      expire: 259200
   SilverStripe\Assets\Flysystem\PublicAdapter:
     class: SilverStripe\S3\Adapter\PublicCachedAdapter
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\PublicAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Adapter.public'
+      cache: '%$League\Flysystem\Cached\Storage\Memory.public'
 
   SilverStripe\S3\Adapter\ProtectedAdapter:
     constructor:
       s3Client: '%$Aws\S3\S3Client'
       bucket: '`AWS_BUCKET_NAME`'
       prefix: '`AWS_PROTECTED_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Adapter.protected:
-      class: League\Flysystem\Cached\Storage\Adapter
-      constructor:
-        adapter: '%$League\Flysystem\Adapter\Local'
-        file: 's3metadata/protected'
-        expire: 259200
+  League\Flysystem\Cached\Storage\Memory.protected:
+    class: League\Flysystem\Cached\Storage\Memory
   SilverStripe\Assets\Flysystem\ProtectedAdapter:
     class: SilverStripe\S3\Adapter\ProtectedCachedAdapter
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\ProtectedAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Adapter.protected'
+      cache: '%$League\Flysystem\Cached\Storage\Memory.protected'
 #---
 Name: silverstripes3-assetscore
 Only:


### PR DESCRIPTION
Solves #51 where using a long-lived cache file on the local tmp filesystem often ends up with poisoned/broken caches due (I think) to a combination of two factors:

 1. Not running the cache expiry logic (so even though the cached data should only live for 72hrs it actually lives forever)
 2. Uploading a file to S3 can return a positive response from the S3 API _before_ S3 is ready to serve that file.

The crux of this issue, as far as I could tell, appears to be that S3 will tell the CMS that the file was uploaded successfully before it is ready to serve it. The CMS then immediately fans out a few requests (e.g. it tries to download the file straight away to render a CMS thumbnail, and in a separate request it tries to download the file to render a larger preview thumbnail). This leads to servers then caching an HTTP 404 for that file, because the S3 API isn't aware of the file that was just uploaded yet.

This solves the issue by using an in-memory cache. The underlying issue may still exist, but isn't exposed because we don't cache the failed API responses beyond a single HTTP call (and anecdotally at least, the `Memory` adapter seems to not cache results where the API fails, leading to a second call that often succeeds).

I would suggest we release this as part of a v2.0.0 of the module as it's _technically_, I think at least, a breaking YML config change.

Note that this issue only seems to affect sites that run on multiple servers e.g. as part of an ECS cluster or some other multi-server architecture. When it's just a single server, the HTTP requests get queued up enough that they don't tend to fail (at least, this is my theory, it's hard to know in reality).