### PR TITLE
Adding param to PublicCDNAdapter to allow for custom asset path folder name. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [*.{yml,js,json,css,scss,eslintrc,feature}]
-indent_size = 2
+indent_size = 4
 indent_style = space
 
 [composer.json]

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [*.{yml,js,json,css,scss,eslintrc,feature}]
-indent_size = 4
+indent_size = 2
 indent_style = space
 
 [composer.json]

--- a/README.md
+++ b/README.md
@@ -11,34 +11,34 @@ policy.
 The module requires a few environment variables to be set. Full details can be
 seen in the `SilverStripeS3AdapterTrait` trait. These are mandatory.
 
--   `AWS_REGION`: The AWS region your S3 bucket is hosted in (e.g. `eu-central-1`)
--   `AWS_BUCKET_NAME`: The name of the S3 bucket to store assets in.
+- `AWS_REGION`: The AWS region your S3 bucket is hosted in (e.g. `eu-central-1`)
+- `AWS_BUCKET_NAME`: The name of the S3 bucket to store assets in.
 
 If running outside of an EC2 instance it will be necessary to specify an API key
 and secret.
 
--   `AWS_ACCESS_KEY_ID`: Your AWS access key that has access to the bucket you
-    want to access
--   `AWS_SECRET_ACCESS_KEY`: Your AWS secret corresponding to the access key
+- `AWS_ACCESS_KEY_ID`: Your AWS access key that has access to the bucket you
+  want to access
+- `AWS_SECRET_ACCESS_KEY`: Your AWS secret corresponding to the access key
 
 **Example YML Config when running outside of EC2:**
 
 ```yml
 ---
 Only:
-    envvarset: AWS_BUCKET_NAME
+  envvarset: AWS_BUCKET_NAME
 After:
-    - "#assetsflysystem"
+  - "#assetsflysystem"
 ---
 SilverStripe\Core\Injector\Injector:
-    Aws\S3\S3Client:
-        constructor:
-            configuration:
-                region: "`AWS_REGION`"
-                version: latest
-                credentials:
-                    key: "`AWS_ACCESS_KEY_ID`"
-                    secret: "`AWS_SECRET_ACCESS_KEY`"
+  Aws\S3\S3Client:
+    constructor:
+      configuration:
+        region: "`AWS_REGION`"
+        version: latest
+        credentials:
+          key: "`AWS_ACCESS_KEY_ID`"
+          secret: "`AWS_SECRET_ACCESS_KEY`"
 ```
 
 ## (Optional) CDN Implementation
@@ -51,8 +51,8 @@ reachable within the `assets` directory of the cdn (for example;
 https://cdn.example.com/assets/Uploads/file.jpg) and set the following
 environment variable:
 
--   `AWS_PUBLIC_CDN_PREFIX`: Your CloudFront distribution domain that has access
-    to the bucket you want to access
+- `AWS_PUBLIC_CDN_PREFIX`: Your CloudFront distribution domain that has access
+  to the bucket you want to access
 
 For example, adding this to your `.env`:
 
@@ -72,28 +72,28 @@ You can override the default `/assets/` path by redeclaring the PublicCDNAdapter
 ---
 Name: silverstripes3-cdn
 Only:
-    envvarset: AWS_PUBLIC_CDN_PREFIX
+  envvarset: AWS_PUBLIC_CDN_PREFIX
 After:
-    - "#assetsflysystem"
-    - "#silverstripes3-flysystem"
+  - "#assetsflysystem"
+  - "#silverstripes3-flysystem"
 ---
 SilverStripe\Core\Injector\Injector:
-    SilverStripe\S3\Adapter\PublicAdapter:
-        class: SilverStripe\S3\Adapter\PublicCDNAdapter
-        constructor:
-            s3Client: '%$Aws\S3\S3Client'
-            bucket: "`AWS_BUCKET_NAME`"
-            prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
-            cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
-            cdnAssetPath: "public" # example of altered path name, which will produce https://cdn.example.com/public/Uploads/file.jpg
+  SilverStripe\S3\Adapter\PublicAdapter:
+    class: SilverStripe\S3\Adapter\PublicCDNAdapter
+    constructor:
+      s3Client: '%$Aws\S3\S3Client'
+      bucket: "`AWS_BUCKET_NAME`"
+      prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
+      cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
+      cdnAssetPath: "public" # example of altered path name, which will produce https://cdn.example.com/public/Uploads/file.jpg
 ```
 
 ## Installation
 
--   Define the environment variables listed above.
--   [Install Composer from
-    https://getcomposer.org](https://getcomposer.org/download/)
--   Run `composer require silverstripe/s3`
+- Define the environment variables listed above.
+- [Install Composer from
+  https://getcomposer.org](https://getcomposer.org/download/)
+- Run `composer require silverstripe/s3`
 
 This will install the most recent applicable version of the module given your
 other Composer requirements.
@@ -129,18 +129,18 @@ Make sure you replace `<bucket-name>` below with the appropriate values.
 
 ```json
 {
-    "Policy": {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Sid": "AddPerm",
-                "Effect": "Allow",
-                "Principal": "*",
-                "Action": "s3:GetObject",
-                "Resource": "arn:aws:s3:::<bucket-name>/public/*"
-            }
-        ]
-    }
+  "Policy": {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AddPerm",
+        "Effect": "Allow",
+        "Principal": "*",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::<bucket-name>/public/*"
+      }
+    ]
+  }
 }
 ```
 
@@ -157,4 +157,4 @@ development.
 
 ## Uninstalling
 
--   Run `composer remove silverstripe/s3` to remove the module.
+- Run `composer remove silverstripe/s3` to remove the module.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ to something like:
 
 `https://cdn.example.com/assets/Uploads/file.jpg`
 
-You can override the default `/assets/` path by redeclaring the PublicCDNAdapter constructor, with the paramater for the `cdnAssetPath` set to a string of your folder name:
+You can override the default `/assets/` path by redeclaring the PublicCDNAdapter constructor, with the paramater for the `cdnAssetsDir` set to a string of your folder name:
 
 ```yml
 ---
@@ -85,7 +85,7 @@ SilverStripe\Core\Injector\Injector:
       bucket: "`AWS_BUCKET_NAME`"
       prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
       cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
-      cdnAssetPath: "public" # example of altered path name, which will produce https://cdn.example.com/public/Uploads/file.jpg
+      cdnAssetsDir: "cms-assets" # example of a custom assets folder name, which will produce https://cdn.example.com/cms-assets/Uploads/file.jpg
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ SilverStripe\Core\Injector\Injector:
       bucket: "`AWS_BUCKET_NAME`"
       prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
       cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
+      options: []
       cdnAssetsDir: "cms-assets" # example of a custom assets folder name, which will produce https://cdn.example.com/cms-assets/Uploads/file.jpg
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,37 +11,35 @@ policy.
 The module requires a few environment variables to be set. Full details can be
 seen in the `SilverStripeS3AdapterTrait` trait. These are mandatory.
 
-* `AWS_REGION`: The AWS region your S3 bucket is hosted in (e.g. `eu-central-1`)
-* `AWS_BUCKET_NAME`: The name of the S3 bucket to store assets in.
+-   `AWS_REGION`: The AWS region your S3 bucket is hosted in (e.g. `eu-central-1`)
+-   `AWS_BUCKET_NAME`: The name of the S3 bucket to store assets in.
 
 If running outside of an EC2 instance it will be necessary to specify an API key
 and secret.
 
-* `AWS_ACCESS_KEY_ID`: Your AWS access key that has access to the bucket you
-  want to access
-* `AWS_SECRET_ACCESS_KEY`: Your AWS secret corresponding to the access key
+-   `AWS_ACCESS_KEY_ID`: Your AWS access key that has access to the bucket you
+    want to access
+-   `AWS_SECRET_ACCESS_KEY`: Your AWS secret corresponding to the access key
 
 **Example YML Config when running outside of EC2:**
 
 ```yml
 ---
 Only:
-  envvarset: AWS_BUCKET_NAME
+    envvarset: AWS_BUCKET_NAME
 After:
-  - '#assetsflysystem'
+    - "#assetsflysystem"
 ---
 SilverStripe\Core\Injector\Injector:
-  Aws\S3\S3Client:
-    constructor:
-      configuration:
-        region: '`AWS_REGION`'
-        version: latest
-        credentials:
-          key: '`AWS_ACCESS_KEY_ID`'
-          secret: '`AWS_SECRET_ACCESS_KEY`'
+    Aws\S3\S3Client:
+        constructor:
+            configuration:
+                region: "`AWS_REGION`"
+                version: latest
+                credentials:
+                    key: "`AWS_ACCESS_KEY_ID`"
+                    secret: "`AWS_SECRET_ACCESS_KEY`"
 ```
-<<<<<<< HEAD
-=======
 
 ## (Optional) CDN Implementation
 
@@ -53,8 +51,8 @@ reachable within the `assets` directory of the cdn (for example;
 https://cdn.example.com/assets/Uploads/file.jpg) and set the following
 environment variable:
 
-* `AWS_PUBLIC_CDN_PREFIX`: Your CloudFront distribution domain that has access
-  to the bucket you want to access
+-   `AWS_PUBLIC_CDN_PREFIX`: Your CloudFront distribution domain that has access
+    to the bucket you want to access
 
 For example, adding this to your `.env`:
 
@@ -68,14 +66,34 @@ to something like:
 
 `https://cdn.example.com/assets/Uploads/file.jpg`
 
->>>>>>> rookie-me-feature/cdn_prefix
+You can override the default `/assets/` path by redeclaring the PublicCDNAdapter constructor, with the paramater for the `cdnAssetPath` set to a string of your folder name:
+
+```yml
+---
+Name: silverstripes3-cdn
+Only:
+    envvarset: AWS_PUBLIC_CDN_PREFIX
+After:
+    - "#assetsflysystem"
+    - "#silverstripes3-flysystem"
+---
+SilverStripe\Core\Injector\Injector:
+    SilverStripe\S3\Adapter\PublicAdapter:
+        class: SilverStripe\S3\Adapter\PublicCDNAdapter
+        constructor:
+            s3Client: '%$Aws\S3\S3Client'
+            bucket: "`AWS_BUCKET_NAME`"
+            prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
+            cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
+            cdnAssetPath: "public" # example of altered path name, which will produce https://cdn.example.com/public/Uploads/file.jpg
+```
 
 ## Installation
 
-* Define the environment variables listed above.
-* [Install Composer from
-  https://getcomposer.org](https://getcomposer.org/download/)
-* Run `composer require silverstripe/s3`
+-   Define the environment variables listed above.
+-   [Install Composer from
+    https://getcomposer.org](https://getcomposer.org/download/)
+-   Run `composer require silverstripe/s3`
 
 This will install the most recent applicable version of the module given your
 other Composer requirements.
@@ -112,17 +130,17 @@ Make sure you replace `<bucket-name>` below with the appropriate values.
 ```json
 {
     "Policy": {
-		"Version":"2012-10-17",
-		"Statement":[
-			{
-				"Sid":"AddPerm",
-				"Effect":"Allow",
-				"Principal":"*",
-				"Action":"s3:GetObject",
-				"Resource":"arn:aws:s3:::<bucket-name>/public/*"
-			}
-		]
-	}
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AddPerm",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::<bucket-name>/public/*"
+            }
+        ]
+    }
 }
 ```
 
@@ -139,4 +157,4 @@ development.
 
 ## Uninstalling
 
-* Run `composer remove silverstripe/s3` to remove the module.
+-   Run `composer remove silverstripe/s3` to remove the module.

--- a/src/Adapter/PublicCDNAdapter.php
+++ b/src/Adapter/PublicCDNAdapter.php
@@ -16,12 +16,12 @@ class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapte
 {
     protected $cdnPrefix;
 
-    protected $cdnAssetPath;
+    protected $cdnAssetsDir;
 
-    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', $cdnAssetPath = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', $cdnAssetsDir = '', array $options = [])
     {
         $this->cdnPrefix = $cdnPrefix;
-        $this->cdnAssetPath = $cdnAssetPath ? $cdnAssetPath : ASSETS_DIR;
+        $this->cdnAssetsDir = $cdnAssetsDir ? $cdnAssetsDir : ASSETS_DIR;
         parent::__construct($client, $bucket, $prefix, $options);
     }
 
@@ -32,7 +32,7 @@ class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapte
      */
     public function getPublicUrl($path)
     {
-        return Controller::join_links($this->cdnPrefix, $this->cdnAssetPath, $path);
+        return Controller::join_links($this->cdnPrefix, $this->cdnAssetsDir, $path);
     }
 
 

--- a/src/Adapter/PublicCDNAdapter.php
+++ b/src/Adapter/PublicCDNAdapter.php
@@ -5,6 +5,7 @@ namespace SilverStripe\S3\Adapter;
 use Aws\S3\S3Client;
 use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
 use SilverStripe\Control\Controller;
+
 use const ASSETS_DIR;
 
 /**
@@ -15,9 +16,12 @@ class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapte
 {
     protected $cdnPrefix;
 
-    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', array $options = [])
+    protected $cdnAssetPath;
+
+    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', $cdnAssetPath = '', array $options = [])
     {
         $this->cdnPrefix = $cdnPrefix;
+        $this->cdnAssetPath = $cdnAssetPath ? $cdnAssetPath : ASSETS_DIR;
         parent::__construct($client, $bucket, $prefix, $options);
     }
 
@@ -28,7 +32,7 @@ class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapte
      */
     public function getPublicUrl($path)
     {
-        return Controller::join_links($this->cdnPrefix, ASSETS_DIR, $path);
+        return Controller::join_links($this->cdnPrefix, $this->cdnAssetPath, $path);
     }
 
 

--- a/src/Adapter/PublicCDNAdapter.php
+++ b/src/Adapter/PublicCDNAdapter.php
@@ -18,7 +18,7 @@ class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapte
 
     protected $cdnAssetsDir;
 
-    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', $cdnAssetsDir = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', array $options = [], $cdnAssetsDir = '')
     {
         $this->cdnPrefix = $cdnPrefix;
         $this->cdnAssetsDir = $cdnAssetsDir ? $cdnAssetsDir : ASSETS_DIR;


### PR DESCRIPTION
Default path extension of `/assets/` doesn't always line up to desired S3 bucket path/origin path, and causes unnecessary issues when this can be easily overridden. Must be fully overridden in the config, but allows for edge-case handling of this path naming.

Just have to redeclare the following config:

```yml
---
Name: silverstripes3-cdn
Only:
  envvarset: AWS_PUBLIC_CDN_PREFIX
After:
  - "#assetsflysystem"
  - "#silverstripes3-flysystem"
---
SilverStripe\Core\Injector\Injector:
  SilverStripe\S3\Adapter\PublicAdapter:
    class: SilverStripe\S3\Adapter\PublicCDNAdapter
    constructor:
      s3Client: '%$Aws\S3\S3Client'
      bucket: "`AWS_BUCKET_NAME`"
      prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
      cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
      cdnAssetPath: "public" # example of altered path name, which will produce https://cdn.example.com/public/Uploads/file.jpg
```

Have updated the README.md to reflect this, as well as ripping out what appeared to be accidental inclusion of `>> HEAD` comments from git, as well as adjusting the .editorconfig to have 2 space tabs instead of 4, which was causing issues with the appearance of the .yml and .json code examples.