### PR TITLE
Flysystem v3

### DIFF
--- a/_config/assets.yml
+++ b/_config/assets.yml
@@ -16,31 +16,40 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       root: '`TEMP_PATH`'
 
+
   SilverStripe\S3\Adapter\PublicAdapter:
     constructor:
       s3Client: '%$Aws\S3\S3Client'
       bucket: '`AWS_BUCKET_NAME`'
       prefix: '`AWS_PUBLIC_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Memory.public:
-    class: League\Flysystem\Cached\Storage\Memory
+  League\Flysystem\Cached\Storage\Psr6Cache.public:
+    class: League\Flysystem\Cached\Storage\Psr6Cache
+    constructor:
+      pool: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter'
+      key: 'flysystem-public'
+      expire: 2592000
   SilverStripe\Assets\Flysystem\PublicAdapter:
     class: SilverStripe\S3\Adapter\PublicCachedAdapter
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\PublicAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Memory.public'
+      cache: '%$League\Flysystem\Cached\Storage\Psr6Cache.public'
 
   SilverStripe\S3\Adapter\ProtectedAdapter:
     constructor:
       s3Client: '%$Aws\S3\S3Client'
       bucket: '`AWS_BUCKET_NAME`'
       prefix: '`AWS_PROTECTED_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Memory.protected:
-    class: League\Flysystem\Cached\Storage\Memory
+  League\Flysystem\Cached\Storage\Psr6Cache.protected:
+    class: League\Flysystem\Cached\Storage\Psr6Cache
+    constructor:
+      pool: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter'
+      key: 'flysystem-protected'
+      expire: 2592000
   SilverStripe\Assets\Flysystem\ProtectedAdapter:
     class: SilverStripe\S3\Adapter\ProtectedCachedAdapter
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\ProtectedAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Memory.protected'
+      cache: '%$League\Flysystem\Cached\Storage\Psr6Cache.protected'
 ---
 Name: silverstripes3-assetscore
 Only:

--- a/_config/assets.yml
+++ b/_config/assets.yml
@@ -16,51 +16,72 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       root: '`TEMP_PATH`'
 
-
   SilverStripe\S3\Adapter\PublicAdapter:
     constructor:
       s3Client: '%$Aws\S3\S3Client'
       bucket: '`AWS_BUCKET_NAME`'
       prefix: '`AWS_PUBLIC_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Psr6Cache.public:
-    class: League\Flysystem\Cached\Storage\Psr6Cache
+  Symfony\Component\Cache\Adapter\FilesystemAdapter.public:
+    class: Symfony\Component\Cache\Adapter\FilesystemAdapter
     constructor:
-      pool: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter'
-      key: 'flysystem-public'
+      namespace: 'flysystem-public'
       expire: 2592000
   SilverStripe\Assets\Flysystem\PublicAdapter:
     class: SilverStripe\S3\Adapter\PublicCachedAdapter
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\PublicAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Psr6Cache.public'
+      cache: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter.public'
+  League\Flysystem\Filesystem.public:
+    class: SilverStripe\Assets\Flysystem\Filesystem
+    constructor:
+      FilesystemAdapter: '%$SilverStripe\Assets\Flysystem\PublicAdapter'
+      FilesystemConfig:
+        visibility: public
 
   SilverStripe\S3\Adapter\ProtectedAdapter:
     constructor:
       s3Client: '%$Aws\S3\S3Client'
       bucket: '`AWS_BUCKET_NAME`'
       prefix: '`AWS_PROTECTED_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Psr6Cache.protected:
-    class: League\Flysystem\Cached\Storage\Psr6Cache
+  Symfony\Component\Cache\Adapter\FilesystemAdapter.protected:
+    class: Symfony\Component\Cache\Adapter\FilesystemAdapter
     constructor:
-      pool: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter'
-      key: 'flysystem-protected'
+      namespace: 'flysystem-protected'
       expire: 2592000
   SilverStripe\Assets\Flysystem\ProtectedAdapter:
     class: SilverStripe\S3\Adapter\ProtectedCachedAdapter
     constructor:
       adapter: '%$SilverStripe\S3\Adapter\ProtectedAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Psr6Cache.protected'
+      cache: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter.protected'
+  League\Flysystem\Filesystem.protected:
+    class: SilverStripe\Assets\Flysystem\Filesystem
+    constructor:
+      FilesystemAdapter: '%$SilverStripe\Assets\Flysystem\ProtectedAdapter'
+      FilesystemConfig:
+        visibility: private
 ---
 Name: silverstripes3-assetscore
 Only:
   envvarset: AWS_BUCKET_NAME
 After:
+  - '#assetsflysystem'
   - '#assetscore'
 ---
 SilverStripe\Core\Injector\Injector:
   # Define our SS asset backend
   SilverStripe\Assets\Storage\AssetStore:
     class: SilverStripe\Assets\Flysystem\FlysystemAssetStore
+    properties:
+      PublicFilesystem: '%$League\Flysystem\Filesystem.public'
+      ProtectedFilesystem: '%$League\Flysystem\Filesystem.protected'
+  SilverStripe\Assets\Storage\GeneratedAssetHandler:
+    class: SilverStripe\Assets\Flysystem\GeneratedAssets
+    properties:
+      Filesystem: '%$League\Flysystem\Filesystem.public'
+  SilverStripe\View\Requirements_Backend:
+    properties:
+      AssetHandler: '%$SilverStripe\Assets\Storage\GeneratedAssetHandler'
+
 ---
 Name: silverstripes3-cdn
 Only:

--- a/_config/tinymce.yml
+++ b/_config/tinymce.yml
@@ -5,7 +5,7 @@ After:
 ---
 SilverStripe\Core\Injector\Injector:
   League\Flysystem\Filesystem.localpublic:
-    class: 'League\Flysystem\Filesystem'
+    class: 'SilverStripe\Assets\Flysystem\Filesystem'
     constructor:
       FilesystemAdapter: '%$SilverStripe\S3\Adapter\TinyMceAdapter'
       FilesystemConfig:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^5.1",
+        "silverstripe/framework": "^5",
         "league/flysystem-aws-s3-v3": "^3.0",
         "silverstripe/vendor-plugin": "^2",
         "jgivoni/flysystem-cache-adapter": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4 || ^5",
-        "league/flysystem-aws-s3-v3": "^1.0",
-        "silverstripe/vendor-plugin": "^1 || ^2",
-        "league/flysystem-cached-adapter": "^1.0"
+        "silverstripe/framework": "^5.1",
+        "league/flysystem-aws-s3-v3": "^3.0",
+        "silverstripe/vendor-plugin": "^2",
+        "jgivoni/flysystem-cache-adapter": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Adapter/CacheAdapter.php
+++ b/src/Adapter/CacheAdapter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\S3\Adapter;
+
+use jgivoni\Flysystem\Cache\CacheAdapter as jgivoniCacheAdapter;
+
+class CacheAdapter extends jgivoniCacheAdapter{
+    public function getAdapter(){
+        return $this->adapter;
+    }
+}

--- a/src/Adapter/ProtectedAdapter.php
+++ b/src/Adapter/ProtectedAdapter.php
@@ -5,6 +5,8 @@ namespace SilverStripe\S3\Adapter;
 use Aws\S3\S3Client;
 use InvalidArgumentException;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use League\Flysystem\AwsS3V3\VisibilityConverter;
+use League\MimeTypeDetection\MimeTypeDetector;
 use SilverStripe\Assets\Flysystem\ProtectedAdapter as SilverstripeProtectedAdapter;
 
 /**
@@ -19,7 +21,7 @@ class ProtectedAdapter extends AwsS3V3Adapter implements SilverstripeProtectedAd
      */
     protected $expiry = 300;
 
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = '', VisibilityConverter $visibility = null, MimeTypeDetector $mimeTypeDetector = null, array $options = [])
     {
         if (!$bucket) {
             throw new InvalidArgumentException("AWS_BUCKET_NAME environment variable not set");
@@ -27,7 +29,7 @@ class ProtectedAdapter extends AwsS3V3Adapter implements SilverstripeProtectedAd
         if (!$prefix) {
             $prefix = 'protected';
         }
-        parent::__construct($client, $bucket, $prefix, $options);
+        parent::__construct($client, $bucket, $prefix, $visibility, $mimeTypeDetector, $options);
     }
 
     /**

--- a/src/Adapter/ProtectedAdapter.php
+++ b/src/Adapter/ProtectedAdapter.php
@@ -4,13 +4,13 @@ namespace SilverStripe\S3\Adapter;
 
 use Aws\S3\S3Client;
 use InvalidArgumentException;
-use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use SilverStripe\Assets\Flysystem\ProtectedAdapter as SilverstripeProtectedAdapter;
 
 /**
  * An adapter that allows the use of AWS S3 to store and transmit assets rather than storing them locally.
  */
-class ProtectedAdapter extends AwsS3Adapter implements SilverstripeProtectedAdapter
+class ProtectedAdapter extends AwsS3V3Adapter implements SilverstripeProtectedAdapter
 {
     /**
      * Pre-signed request expiration time in seconds, or relative string

--- a/src/Adapter/ProtectedAdapter.php
+++ b/src/Adapter/ProtectedAdapter.php
@@ -60,7 +60,7 @@ class ProtectedAdapter extends AwsS3V3Adapter implements SilverstripeProtectedAd
      */
     public function getProtectedUrl($path)
     {
-        $cmd = $this->getClient()
+        $cmd = $this->client
             ->getCommand('GetObject', [
                 'Bucket' => $this->getBucket(),
                 'Key' => $this->applyPathPrefix($path),
@@ -72,7 +72,7 @@ class ProtectedAdapter extends AwsS3V3Adapter implements SilverstripeProtectedAd
             $expiry = "+{$expiry} seconds";
         }
 
-        return (string)$this->getClient()
+        return (string)$this->client
             ->createPresignedRequest($cmd, $expiry)
             ->getUri();
     }

--- a/src/Adapter/ProtectedCachedAdapter.php
+++ b/src/Adapter/ProtectedCachedAdapter.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\S3\Adapter;
 
-use League\Flysystem\Cached\CachedAdapter;
 use SilverStripe\Assets\Flysystem\ProtectedAdapter;
+use jgivoni\Flysystem\Cache\CacheAdapter;
 
-class ProtectedCachedAdapter extends CachedAdapter implements ProtectedAdapter
+class ProtectedCachedAdapter extends CacheAdapter implements ProtectedAdapter
 {
     public function getProtectedUrl($path)
     {

--- a/src/Adapter/ProtectedCachedAdapter.php
+++ b/src/Adapter/ProtectedCachedAdapter.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\S3\Adapter;
 
 use SilverStripe\Assets\Flysystem\ProtectedAdapter;
-use jgivoni\Flysystem\Cache\CacheAdapter;
 
 class ProtectedCachedAdapter extends CacheAdapter implements ProtectedAdapter
 {

--- a/src/Adapter/PublicAdapter.php
+++ b/src/Adapter/PublicAdapter.php
@@ -4,10 +4,10 @@ namespace SilverStripe\S3\Adapter;
 
 use Aws\S3\S3Client;
 use InvalidArgumentException;
-use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
 
-class PublicAdapter extends AwsS3Adapter implements SilverstripePublicAdapter
+class PublicAdapter extends AwsS3V3Adapter implements SilverstripePublicAdapter
 {
     public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
     {

--- a/src/Adapter/PublicAdapter.php
+++ b/src/Adapter/PublicAdapter.php
@@ -5,11 +5,13 @@ namespace SilverStripe\S3\Adapter;
 use Aws\S3\S3Client;
 use InvalidArgumentException;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use League\Flysystem\AwsS3V3\VisibilityConverter;
+use League\MimeTypeDetection\MimeTypeDetector;
 use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
 
 class PublicAdapter extends AwsS3V3Adapter implements SilverstripePublicAdapter
 {
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3Client $client, $bucket, $prefix = '', VisibilityConverter $visibility = null, MimeTypeDetector $mimeTypeDetector = null, array $options = [])
     {
         if (!$bucket) {
             throw new InvalidArgumentException("AWS_BUCKET_NAME environment variable not set");
@@ -17,7 +19,7 @@ class PublicAdapter extends AwsS3V3Adapter implements SilverstripePublicAdapter
         if (!$prefix) {
             $prefix = 'public';
         }
-        parent::__construct($client, $bucket, $prefix, $options);
+        parent::__construct($client, $bucket, $prefix, $visibility, $mimeTypeDetector, $options);
     }
 
     /**

--- a/src/Adapter/PublicAdapter.php
+++ b/src/Adapter/PublicAdapter.php
@@ -6,6 +6,7 @@ use Aws\S3\S3Client;
 use InvalidArgumentException;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\AwsS3V3\VisibilityConverter;
+use League\Flysystem\Config;
 use League\MimeTypeDetection\MimeTypeDetector;
 use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
 
@@ -29,6 +30,7 @@ class PublicAdapter extends AwsS3V3Adapter implements SilverstripePublicAdapter
      */
     public function getPublicUrl($path)
     {
-        return $this->getClient()->getObjectUrl($this->getBucket(), $this->applyPathPrefix($path));
+
+        return $this->publicUrl($path, new Config());
     }
 }

--- a/src/Adapter/PublicCachedAdapter.php
+++ b/src/Adapter/PublicCachedAdapter.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\S3\Adapter;
 
 use SilverStripe\Assets\Flysystem\PublicAdapter;
-use jgivoni\Flysystem\Cache\CacheAdapter;
 
 class PublicCachedAdapter extends CacheAdapter implements PublicAdapter
 {

--- a/src/Adapter/PublicCachedAdapter.php
+++ b/src/Adapter/PublicCachedAdapter.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\S3\Adapter;
 
-use League\Flysystem\Cached\CachedAdapter;
 use SilverStripe\Assets\Flysystem\PublicAdapter;
+use jgivoni\Flysystem\Cache\CacheAdapter;
 
-class PublicCachedAdapter extends CachedAdapter implements PublicAdapter
+class PublicCachedAdapter extends CacheAdapter implements PublicAdapter
 {
     public function getPublicUrl($path)
     {


### PR DESCRIPTION
This pull request updates this module so you can use flysytem v3 with silverstripe assets v2.1 (SS v5.1+) - Fixes #62 

Biggest changes are using a new cache provider and updating all dependencies.  Also setting default cache to be written to the filesystem.  Users upgrading will need to double check their configuration after upgrading as the new cache provider is a PSR 6 cache provider.

This would need to be released as a new major version.  I have tested this on one of my sites and all appears to be working okay.  Major item that may need to be addressed is the file listing in the admin asset manager is extremely slow on first call until things are cached. 