### PR TITLE
modify PublicCDNAdapter for Flysystem v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\S3\Adapter\PublicCDNAdapter
     constructor:
       s3Client: '%$Aws\S3\S3Client'
-      bucket: "`AWS_BUCKET_NAME`"
-      prefix: "`AWS_PUBLIC_BUCKET_PREFIX`"
-      cdnPrefix: "`AWS_PUBLIC_CDN_PREFIX`"
+      bucket: '`AWS_BUCKET_NAME`'
+      prefix: '`AWS_PUBLIC_BUCKET_PREFIX`'
+      visibility: null
+      mimeTypeDetector: null
+      cdnPrefix: '`AWS_PUBLIC_CDN_PREFIX`'
       options: []
       cdnAssetsDir: "cms-assets" # example of a custom assets folder name, which will produce https://cdn.example.com/cms-assets/Uploads/file.jpg
 ```

--- a/_config/assets.yml
+++ b/_config/assets.yml
@@ -97,4 +97,6 @@ SilverStripe\Core\Injector\Injector:
       s3Client: '%$Aws\S3\S3Client'
       bucket: '`AWS_BUCKET_NAME`'
       prefix: '`AWS_PUBLIC_BUCKET_PREFIX`'
+      visibility: null
+      mimeTypeDetector: null
       cdnPrefix: '`AWS_PUBLIC_CDN_PREFIX`'

--- a/src/Adapter/PublicCDNAdapter.php
+++ b/src/Adapter/PublicCDNAdapter.php
@@ -18,11 +18,11 @@ class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapte
 
     protected $cdnAssetsDir;
 
-    public function __construct(S3Client $client, $bucket, $prefix = '', $cdnPrefix = '', array $options = [], $cdnAssetsDir = '')
+    public function __construct(S3Client $client, $bucket, $prefix = '', VisibilityConverter $visibility = null, MimeTypeDetector $mimeTypeDetector = null, $cdnPrefix = '', array $options = [], $cdnAssetsDir = '')
     {
         $this->cdnPrefix = $cdnPrefix;
         $this->cdnAssetsDir = $cdnAssetsDir ? $cdnAssetsDir : ASSETS_DIR;
-        parent::__construct($client, $bucket, $prefix, $options);
+        parent::__construct($client, $bucket, $prefix, $visibility, $mimeTypeDetector, $options);
     }
 
     /**


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-s3/pull/63 forgot to also update the PublicCDNAdapter.

I set the values by default to null because im not sure what functionality we need here

The problem was, without this change, the constructor would set $options as VisibilityConverter