### PR TITLE
SilverStripe 6 Upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^6",
         "league/flysystem-aws-s3-v3": "^3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "silverstripe/framework": "^5",
-        "league/flysystem-aws-s3-v3": "^3",
-        "silverstripe/vendor-plugin": "^2"
+        "league/flysystem-aws-s3-v3": "^3"
     },
     "autoload": {
         "psr-4": {
@@ -26,5 +25,12 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/src/Tasks/S3DebugAsset.php
+++ b/src/Tasks/S3DebugAsset.php
@@ -3,31 +3,35 @@
 namespace Silverstripe\S3\Tasks;
 
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\PolyExecution\PolyOutput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 
 class S3DebugAsset extends BuildTask
 {
-    protected $title = 'S3 Debug Asset';
+    protected string $title = 'S3 Debug Asset';
 
-    private static $segment = 'S3DebugAsset';
+    protected static string $commandName = 'S3DebugAsset';
 
-    protected $description = 'Debug S3 Asset';
+    protected static string $description = 'Debug S3 Asset';
 
-    public function run($request)
+    protected function execute(InputInterface $input, PolyOutput $output) :int
     {
         $fileId = $request->getVar('fileId');
 
         if (!$fileId) {
             echo 'Please provide fileId';
-            return;
+            return Command::INVALID;
         }
 
         $file = \SilverStripe\Assets\File::get()->byId($fileId);
 
         if (!$file) {
             echo 'File not found';
-            return;
+            return Command::FAILURE;
         }
 
-        var_dump($file->getAbsoluteURL());
+        $output->writeln($file->getAbsoluteURL());
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
## Description
This is to upgrade the S3 module to be able to run with SilverStripe 6.0.  Due to the Build task in this repo for testing it is required to only work with SilverStripe 6.0 so will need a new major tag of 5.0.0

## Manual testing steps
To test simply install like normal and configure a base SilverStripe 6.0 site.  We have verified this on one of our clients sites and upgraded fully to SS 6.0

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
